### PR TITLE
A couple fixes

### DIFF
--- a/ESISharp/ESIEve.SSO.Operations.cs
+++ b/ESISharp/ESIEve.SSO.Operations.cs
@@ -120,7 +120,6 @@ namespace ESISharp
                 "authorization_code",
                 "code",
                 AuthCode);
-            GetAccessTokenTask.Wait();
             return GetAccessTokenTask.Result;
         }
 
@@ -130,7 +129,6 @@ namespace ESISharp
                 "refresh_token",
                 "refresh_token",
                 AuthToken.RefreshToken);
-            GetAccessTokenTask.Wait();
             AccessToken Token = JsonConvert.DeserializeObject<AccessToken>(GetAccessToken(GetAccessTokenTask.Result));
             AuthToken = new AuthToken(Token.access_token, Token.token_type, Token.refresh_token, Token.expires_in);
         }
@@ -141,7 +139,6 @@ namespace ESISharp
                 "refresh_token",
                 "refresh_token",
                 RefreshToken);
-            GetAccessTokenTask.Wait();
             AccessToken Token = JsonConvert.DeserializeObject<AccessToken>(GetAccessTokenTask.Result);
             AuthToken = new AuthToken(Token.access_token, Token.token_type, Token.refresh_token, Token.expires_in);
         }
@@ -155,8 +152,8 @@ namespace ESISharp
                 {
                     new KeyValuePair<string, string>("grant_type", Grant),
                     new KeyValuePair<string, string>(CodeType, Code)
-                }));
-            ResponseString = await Response.Content.ReadAsStringAsync();
+                })).ConfigureAwait(false);
+            ResponseString = await Response.Content.ReadAsStringAsync().ConfigureAwait(false);
             return ResponseString;
         }
 

--- a/ESISharp/Web/EsiRequest.cs
+++ b/ESISharp/Web/EsiRequest.cs
@@ -9,25 +9,24 @@ namespace ESISharp.Web
 {
     internal class EsiRequest
     {
-        private readonly ESIEve.Public PublicEasyObject;
+        private readonly ESIEve EasyObject;
         private readonly string BaseUrl = "https://esi.tech.ccp.is";
         private readonly Route Route;
         private readonly string Path;
         private readonly DataSource DataSource;
-        private string RequestUrl => string.Concat(string.Concat(BaseUrl, Route.Value), string.Concat(Path, "?datasource=" + DataSource.Value));
+        private string RequestUrl => $"{BaseUrl}{Route.Value}{Path}?datasource={DataSource.Value}";
 
         internal EsiRequest(ESIEve SwaggerObject, string RequestPath)
         {
-            PublicEasyObject = (ESIEve.Public)SwaggerObject;
-            Route = PublicEasyObject.Route;
+            EasyObject = SwaggerObject;
+            Route = EasyObject.Route;
             Path = RequestPath;
-            DataSource = PublicEasyObject.DataSource;
+            DataSource = EasyObject.DataSource;
         }
 
         internal string Get()
         {
             var Response = GetAsync(RequestUrl);
-            Response.Wait();
             return Response.Result;
         }
 
@@ -36,30 +35,28 @@ namespace ESISharp.Web
             var ArgString = Utils.ConstructUrlArgs(QueryArguments);
             var ArgumentRequest = string.Concat(RequestUrl, ArgString);
             var Response = GetAsync(ArgumentRequest);
-            Response.Wait();
             return Response.Result;
         }
 
         private async Task<string> GetAsync(string Url)
         {
-            var response = await PublicEasyObject.QueryClient.GetAsync(Url);
-            return await response.Content.ReadAsStringAsync();
+            var response = await EasyObject.QueryClient.GetAsync(Url).ConfigureAwait(false);
+            return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         }
 
         internal string Post(object Data)
         {
             var Response = PostAsync(RequestUrl, Data);
-            Response.Wait();
             return Response.Result;
         }
 
         private async Task<string> PostAsync(string Url, object Data)
         {
-            PublicEasyObject.QueryClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            EasyObject.QueryClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             var JsonString = JsonConvert.SerializeObject(Data);
             var PostData = new StringContent(JsonString, Encoding.UTF8, "application/json");
-            var Response = await PublicEasyObject.QueryClient.PostAsync(Url, PostData);
-            return await Response.Content.ReadAsStringAsync();
+            var Response = await EasyObject.QueryClient.PostAsync(Url, PostData).ConfigureAwait(false);
+            return await Response.Content.ReadAsStringAsync().ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
* Fixed an exception when trying to call public endpoints from an authed object.
* Added .ConfigureAwait(false) to some calls to avoid deadlocks if called from a UI thread.
* Added a basic lock to avoid multiple threads making duplicate auth requests.
* Removed redundant calls to Task.Wait(). Accessing Task.Result already waits for completion.