### PR TITLE
Fix 'Registy' typo.

### DIFF
--- a/ESISharp/ESIEve.SSO.Operations.cs
+++ b/ESISharp/ESIEve.SSO.Operations.cs
@@ -106,7 +106,7 @@ namespace ESISharp
             {
                 ReplyHeaderChar = @"?";
             }
-            var UrlHeader = CallbackProtocol + @":///" + ReplyHeaderChar;
+            var UrlHeader = CallbackUrl + ReplyHeaderChar;
             var ReplyArgs = RouterReply.Split(new string[] { UrlHeader }, StringSplitOptions.None)
                             .SelectMany(p => p.Split('&'))
                             .Where(m => m.Contains('='))

--- a/ESISharp/ESIEve.SSO.Operations.cs
+++ b/ESISharp/ESIEve.SSO.Operations.cs
@@ -273,7 +273,7 @@ namespace ESISharp
         }
 
         /// <summary>Verify information of the callback protocol.<para>Key will be create if it doesn't exist, or overwritten if there is an error.</para></summary>
-        public void VerifyCallbackProtocolRegistyKey()
+        public void VerifyCallbackProtocolRegistryKey()
         {
             var Protocol = CallbackProtocol;
             var RouterCommand = @"""" + @AuthRouterFilePath + @""" ""%1""";

--- a/ESISharp/ESIEve.SSO.cs
+++ b/ESISharp/ESIEve.SSO.cs
@@ -18,13 +18,14 @@ namespace ESISharp
 
         internal string AuthRouterFileDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
         internal string AuthRouterFileName = "EveSSOAuthRouter";
-        internal string CallbackProtocol = "eveosso";
+        internal string CallbackProtocol = "eveauth-app";
         internal List<Scope> AuthorizedScopes = new List<Scope>() { Scope.None };
         internal List<Scope> RequestedScopes = new List<Scope>() { Scope.None };
         internal bool ReauthorizeScopes = false;
 
         internal string AuthRouterFilePath => Path.Combine(AuthRouterFileDirectory, AuthRouterFileName + ".exe");
-        internal string CallbackUrl => string.Concat(CallbackProtocol, @"://");
+        internal string CallBackPath => "callback/";
+        internal string CallbackUrl => string.Concat(CallbackProtocol, @"://", CallBackPath);
         internal string ScopesUrl => string.Join(" ", RequestedScopes.Select(s => s.Value));
 
         internal AuthToken AuthToken;

--- a/ESISharp/ESISharp.csproj
+++ b/ESISharp/ESISharp.csproj
@@ -32,9 +32,8 @@
     <CodeAnalysisRuleSet>ESISharp.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/ESISharp/Path/Character/Wallet.cs
+++ b/ESISharp/Path/Character/Wallet.cs
@@ -21,5 +21,25 @@ namespace ESISharp.ESIPath.Character
             var Path = $"/characters/{CharacterID.ToString()}/wallet/";
             return new EsiRequest(EasyObject, Path, EsiWebMethod.AuthGet);
         }
+
+        /// <summary>Get Character's wallet journal</summary>
+        /// <remarks>Requires SSO Authentication, using "read_character_wallet" scope</remarks>
+        /// <param name="CharacterID">(Int32) Character ID</param>
+        /// <returns>EsiRequest</returns>
+        public EsiRequest GetWalletJounal(int CharacterID)
+        {
+            var Path = $"/characters/{CharacterID.ToString()}/wallet/journal/";
+            return new EsiRequest(EasyObject, Path, EsiWebMethod.AuthGet);
+        }
+
+        /// <summary>Get Character's wallet transactions</summary>
+        /// <remarks>Requires SSO Authentication, using "read_character_wallet" scope</remarks>
+        /// <param name="CharacterID">(Int32) Character ID</param>
+        /// <returns>EsiRequest</returns>
+        public EsiRequest GetWalletTransactions(int CharacterID)
+        {
+            var Path = $"/characters/{CharacterID.ToString()}/wallet/transactions/";
+            return new EsiRequest(EasyObject, Path, EsiWebMethod.AuthGet);
+        }
     }
 }

--- a/ESISharp/Path/Character/Wallet.cs
+++ b/ESISharp/Path/Character/Wallet.cs
@@ -12,13 +12,13 @@ namespace ESISharp.ESIPath.Character
             EasyObject = EasyEve;
         }
 
-        /// <summary>Get Character's wallets and balances</summary>
+        /// <summary>Get Character's wallet balance</summary>
         /// <remarks>Requires SSO Authentication, using "read_character_wallet" scope</remarks>
         /// <param name="CharacterID">(Int32) Character ID</param>
         /// <returns>EsiRequest</returns>
-        public EsiRequest GetWallets(int CharacterID)
+        public EsiRequest GetWalletBalance(int CharacterID)
         {
-            var Path = $"/characters/{CharacterID.ToString()}/wallets/";
+            var Path = $"/characters/{CharacterID.ToString()}/wallet/";
             return new EsiRequest(EasyObject, Path, EsiWebMethod.AuthGet);
         }
     }

--- a/ESISharp/packages.config
+++ b/ESISharp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You application will require permissions to write to the Registry to create the 
 
 By default, the router filename is *EveSSOAuthRouter* and must be located in the same directory as the ESISharp library.<br/>
 The default protocol is *eveosso*. (Full callback url is ***eveosso://***)<br/>
-To create or repair the required registry key, run `ESIEve.SSO.VerifyCallbackProtocolRegistyKey()`
+To create or repair the required registry key, run `ESIEve.SSO.VerifyCallbackProtocolRegistryKey()`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ It's filename, location, and operating protocol is fully configurable for your a
 You application will require permissions to write to the Registry to create the forwarding protocol for the AuthRouter.
 
 By default, the router filename is *EveSSOAuthRouter* and must be located in the same directory as the ESISharp library.<br/>
-The default protocol is *eveosso*. (Full callback url is ***eveosso://***)<br/>
+The default protocol is *eveauth-app* and the default path is *callback/*. (Full callback url is ***eveauth-app://callback/***)<br/>
 To create or repair the required registry key, run `ESIEve.SSO.VerifyCallbackProtocolRegistryKey()`
 
 ---


### PR DESCRIPTION
Fixes a typo in the code (and its reference in the README): 'Registy' should be 'Registry'.