### PR TITLE
Fix 'Registy' typo.

### DIFF
--- a/ESISharp/ESIEve.SSO.Operations.cs
+++ b/ESISharp/ESIEve.SSO.Operations.cs
@@ -273,7 +273,7 @@ namespace ESISharp
         }
 
         /// <summary>Verify information of the callback protocol.<para>Key will be create if it doesn't exist, or overwritten if there is an error.</para></summary>
-        public void VerifyCallbackProtocolRegistyKey()
+        public void VerifyCallbackProtocolRegistryKey()
         {
             var Protocol = CallbackProtocol;
             var RouterCommand = @"""" + @AuthRouterFilePath + @""" ""%1""";

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You application will require permissions to write to the Registry to create the 
 
 By default, the router filename is *EveSSOAuthRouter* and must be located in the same directory as the ESISharp library.<br/>
 The default protocol is *eveosso*. (Full callback url is ***eveosso://***)<br/>
-To create or repair the required registry key, run `ESIEve.SSO.VerifyCallbackProtocolRegistyKey()`
+To create or repair the required registry key, run `ESIEve.SSO.VerifyCallbackProtocolRegistryKey()`
 
 ---
 


### PR DESCRIPTION
Fixes a typo in the code (and its reference in the README): 'Registy' should be 'Registry'.

See also #17.