### PR TITLE
Make determining the callback URL header more robust.

### DIFF
--- a/ESISharp/ESIEve.SSO.Operations.cs
+++ b/ESISharp/ESIEve.SSO.Operations.cs
@@ -106,7 +106,7 @@ namespace ESISharp
             {
                 ReplyHeaderChar = @"?";
             }
-            var UrlHeader = CallbackProtocol + @":///" + ReplyHeaderChar;
+            var UrlHeader = CallbackUrl + ReplyHeaderChar;
             var ReplyArgs = RouterReply.Split(new string[] { UrlHeader }, StringSplitOptions.None)
                             .SelectMany(p => p.Split('&'))
                             .Where(m => m.Contains('='))


### PR DESCRIPTION
Currently the callback url is determined at two separate places in the code (`ESIEve.SSO.cs` and `ESIEve.SSO.Operations.cs`). This PR makes it so that the callback url is only determined in `ESIEve.SSO.cs`, and is then referenced as a class field directly in `ESIEve.SSO.Operations.cs`.