### PR TITLE
Update the default callback url to conform to CCP's new rules.

### DIFF
--- a/ESISharp/ESIEve.SSO.Operations.cs
+++ b/ESISharp/ESIEve.SSO.Operations.cs
@@ -273,7 +273,7 @@ namespace ESISharp
         }
 
         /// <summary>Verify information of the callback protocol.<para>Key will be create if it doesn't exist, or overwritten if there is an error.</para></summary>
-        public void VerifyCallbackProtocolRegistyKey()
+        public void VerifyCallbackProtocolRegistryKey()
         {
             var Protocol = CallbackProtocol;
             var RouterCommand = @"""" + @AuthRouterFilePath + @""" ""%1""";

--- a/ESISharp/ESIEve.SSO.cs
+++ b/ESISharp/ESIEve.SSO.cs
@@ -18,13 +18,14 @@ namespace ESISharp
 
         internal string AuthRouterFileDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
         internal string AuthRouterFileName = "EveSSOAuthRouter";
-        internal string CallbackProtocol = "eveosso";
+        internal string CallbackProtocol = "eveauth-app";
         internal List<Scope> AuthorizedScopes = new List<Scope>() { Scope.None };
         internal List<Scope> RequestedScopes = new List<Scope>() { Scope.None };
         internal bool ReauthorizeScopes = false;
 
         internal string AuthRouterFilePath => Path.Combine(AuthRouterFileDirectory, AuthRouterFileName + ".exe");
-        internal string CallbackUrl => string.Concat(CallbackProtocol, @"://");
+        internal string CallBackPath => "callback/";
+        internal string CallbackUrl => string.Concat(CallbackProtocol, @"://", CallBackPath);
         internal string ScopesUrl => string.Join(" ", RequestedScopes.Select(s => s.Value));
 
         internal AuthToken AuthToken;

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You application will require permissions to write to the Registry to create the 
 
 By default, the router filename is *EveSSOAuthRouter* and must be located in the same directory as the ESISharp library.<br/>
 The default protocol is *eveosso*. (Full callback url is ***eveosso://***)<br/>
-To create or repair the required registry key, run `ESIEve.SSO.VerifyCallbackProtocolRegistyKey()`
+To create or repair the required registry key, run `ESIEve.SSO.VerifyCallbackProtocolRegistryKey()`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ It's filename, location, and operating protocol is fully configurable for your a
 You application will require permissions to write to the Registry to create the forwarding protocol for the AuthRouter.
 
 By default, the router filename is *EveSSOAuthRouter* and must be located in the same directory as the ESISharp library.<br/>
-The default protocol is *eveosso*. (Full callback url is ***eveosso://***)<br/>
+The default protocol is *eveauth-app* and the default path is *callback/*. (Full callback url is ***eveauth-app://callback/***)<br/>
 To create or repair the required registry key, run `ESIEve.SSO.VerifyCallbackProtocolRegistryKey()`
 
 ---


### PR DESCRIPTION
This PR breaks existing EVE API applications using the default callback settings.

This PR updates the default callback protocol to conform to CCP's new protocol rules: callback protocols must be either `http` or `https`, or must start with `eveauth`. This PR makes it so that the default callback protocol is `eveauth-app`.

Additionally, callbacks now require a path. This PR sets the default path to `callback`. I.e., the new default callback url is `eveauth-app://callback/`.

Includes PR #18.