### PR TITLE
Add endpoint for market types with active orders.

### DIFF
--- a/ESISharp/Path/Market.cs
+++ b/ESISharp/Path/Market.cs
@@ -118,7 +118,7 @@ namespace ESISharp.ESIPath
         /// <summary>
         /// Get type IDs with active orders in a Region (First Page)
         /// </summary>
-        /// <param name="RegionID"></param>
+        /// <param name="RegionID">(Int32 Region ID)</param>
         /// <returns></returns>
         public EsiRequest GetMarketTypes(int RegionID)
         {

--- a/ESISharp/Path/Market.cs
+++ b/ESISharp/Path/Market.cs
@@ -114,6 +114,32 @@ namespace ESISharp.ESIPath
             var Path = $"/markets/groups/{GroupID.ToString()}/";
             return new EsiRequest(EasyObject, Path, EsiWebMethod.Get);
         }
+
+        /// <summary>
+        /// Get type IDs with active orders in a Region (First Page)
+        /// </summary>
+        /// <param name="RegionID"></param>
+        /// <returns></returns>
+        public EsiRequest GetMarketTypes(int RegionID)
+        {
+            return GetMarketTypes(RegionID, 1);
+        }
+
+        /// <summary>
+        /// Get type IDs with active orders in a Region
+        /// </summary>
+        /// <param name="RegionID">(Int32 Region ID)</param>
+        /// <param name="Page">(Int32) Page number</param>
+        /// <returns></returns>
+        public EsiRequest GetMarketTypes(int RegionID, int Page)
+        {
+            var Path = $"/markets/{RegionID.ToString()}/types/";
+            var Data = new
+            {
+                page = Page
+            };
+            return new EsiRequest(EasyObject, Path, EsiWebMethod.Get, Data);
+        }
     }
 
     /// <summary>Public and Authenticated Market paths</summary>


### PR DESCRIPTION
Adds an endpoint to retrieve all item type IDs that have active market orders in a region.