### PR TITLE
Fix issue where refreshing access tokens resulted in invalid tokens.

### DIFF
--- a/ESISharp/ESIEve.SSO.Operations.cs
+++ b/ESISharp/ESIEve.SSO.Operations.cs
@@ -130,7 +130,7 @@ namespace ESISharp
                 "refresh_token",
                 "refresh_token",
                 AuthToken.RefreshToken);
-            AccessToken Token = JsonConvert.DeserializeObject<AccessToken>(GetAccessToken(GetAccessTokenTask.Result));
+            AccessToken Token = JsonConvert.DeserializeObject<AccessToken>(GetAccessTokenTask.Result);
             AuthToken = new AuthToken(Token.access_token, Token.token_type, Token.refresh_token, Token.expires_in);
         }
 


### PR DESCRIPTION
When refreshing an access token, the refresh request is sent twice.

The first request has the current refresh token as payload, and the second request has the result of the first request as payload. This second request is invalid, and results in an invalid access token.

As such, authenticated clients stop functioning correctly once the first access token expires after 20 minutes.

This pull request fixes that issue.