### PR TITLE
Enable fetching paged region orders for all item types.

### DIFF
--- a/ESISharp/Path/Market.cs
+++ b/ESISharp/Path/Market.cs
@@ -57,7 +57,7 @@ namespace ESISharp.ESIPath
         /// <param name="TypeID">(Int32) Type ID</param>
         /// <param name="OrderType">(MarketOrderType) Market Order Type</param>
         /// <returns>EsiRequest</returns>
-        public EsiRequest GetRegionOrders(int RegionID, int TypeID, MarketOrderType OrderType)
+        public EsiRequest GetRegionOrders(int RegionID, int? TypeID, MarketOrderType OrderType)
         {
             return GetRegionOrders(RegionID, TypeID, OrderType.Value, 1);
         }
@@ -67,7 +67,7 @@ namespace ESISharp.ESIPath
         /// <param name="TypeID">(Int32) Type ID</param>
         /// <param name="OrderType">(String) Market Order Type</param>
         /// <returns>EsiRequest</returns>
-        public EsiRequest GetRegionOrders(int RegionID, int TypeID, string OrderType)
+        public EsiRequest GetRegionOrders(int RegionID, int? TypeID, string OrderType)
         {
             return GetRegionOrders(RegionID, TypeID, OrderType, 1);
         }
@@ -78,7 +78,7 @@ namespace ESISharp.ESIPath
         /// <param name="OrderType">(MarketOrderType) Market Order Type</param>
         /// <param name="Page">(Int32) Page number</param>
         /// <returns>EsiRequest</returns>
-        public EsiRequest GetRegionOrders(int RegionID, int TypeID, MarketOrderType OrderType, int Page)
+        public EsiRequest GetRegionOrders(int RegionID, int? TypeID, MarketOrderType OrderType, int Page)
         {
             return GetRegionOrders(RegionID, TypeID, OrderType.Value, Page);
         }


### PR DESCRIPTION
Currently to fetch *paged* regional orders for all item types (and not just a single type id) only the following method can be used:

`GetRegionOrders(int RegionID, int? TypeID, string OrderType, int Page)`

This PR makes `TypeID` nullable in almost all regional order methods, so e.g. also the following method can be used:

`GetRegionOrders(int RegionID, int? TypeID, MarketOrderType OrderType, int Page)`

Note that this might not be the most beautiful solution. As per the [ESI documentation](https://esi.tech.ccp.is/latest/#!/Market/get_markets_region_id_orders), if no type id is present, the order type is ignored. Perhaps a minor refactor of the market regional order path is required.